### PR TITLE
feature: Create TeleIRC env file using Jinja2 templates.

### DIFF
--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -45,7 +45,7 @@
       state: directory
       mode: "u=rw,g=rx,o=rx"
   - name: Ensure the TeleIRC configuration is in place
-    copy:
+    ansible.builtin.template:
       src: templates/teleirc-env.j2
       dest: /etc/teleirc/env
       owner: "{{ user_name }}"
@@ -53,8 +53,8 @@
       mode: "u=rw"
       remote_src: yes
   - name: Ensure the TeleIRC SystemD service is in place
-    copy:
-      src: files/teleirc.service
+    ansible.builtin.template:
+      src: templates/teleirc.service.j2
       dest: /etc/systemd/system/teleirc.service
       owner: "{{ user_name }}"
       group: "{{ user_name }}"

--- a/ansible/templates/teleirc-env.j2
+++ b/ansible/templates/teleirc-env.j2
@@ -24,20 +24,20 @@ IRC_CERT_ALLOW_SELFSIGNED=false
 
 
 #####----- IRC channel settings -----#####
-IRC_CHANNEL="#channel"
+IRC_CHANNEL="{{ irc_channel }}"
 IRC_CHANNEL_KEY=""
 IRC_BLACKLIST=""
 
 
 #####----- IRC bot settings -----#####
-IRC_BOT_NAME=tg-bridge-bot
-IRC_BOT_REALNAME="Powered by TeleIRC <github.com/RITlug/teleirc>"
+IRC_BOT_NAME="{{ irc_bot_name }}"
+IRC_BOT_REALNAME="{{ irc_bot_realname }}"
 IRC_BOT_IDENT="teleirc"
 
 # NickServ options
 IRC_NICKSERV_SERVICE=NickServ
-IRC_NICKSERV_USER=""
-IRC_NICKSERV_PASS=""
+IRC_NICKSERV_USER="{{ irc_nickserv_user }}"
+IRC_NICKSERV_PASS="{{ irc_nickserv_pass }}"
 
 
 #####----- IRC message settings -----#####
@@ -59,8 +59,8 @@ IRC_QUIT_MESSAGE="TeleIRC bridge stopped."
 #                                                                             #
 ###############################################################################
 
-TELEGRAM_CHAT_ID=-0000000000000
-TELEIRC_TOKEN=000000000:AAAAAAaAAa2AaAAaoAAAA-a_aaAAaAaaaAA
+TELEGRAM_CHAT_ID={{ telegram_chat_id }}
+TELEIRC_TOKEN={{ teleirc_token }}
 MAX_MESSAGES_PER_MINUTE=20
 SHOW_ACTION_MESSAGE=true
 SHOW_JOIN_MESSAGE=false
@@ -77,4 +77,4 @@ SHOW_DISCONNECT_MESSAGE=true
 ###############################################################################
 
 USE_IMGUR_FOR_IMAGES=true
-IMGUR_CLIENT_ID=7d6b00b87043f58
+IMGUR_CLIENT_ID={{ imgur_client_id }}

--- a/ansible/templates/teleirc.service.j2
+++ b/ansible/templates/teleirc.service.j2
@@ -5,7 +5,7 @@ After=multi-user.target
 
 [Service]
 Type=simple
-User=teleirc
+User={{ user_name }}
 ExecStart=/usr/local/bin/teleirc -conf /etc/teleirc/env
 Restart=always
 RestartSec=60

--- a/ansible/vars/ansible_sample.json
+++ b/ansible/vars/ansible_sample.json
@@ -1,5 +1,13 @@
 {
     "user_name": "",
     "user_shell": "/bin/bash",
-    "public_ssh_keys_url": "https://github.com/da-edra.keys"
+    "public_ssh_keys_url": "https://github.com/da-edra.keys",
+    "irc_channel": "#archlinux-mx",
+    "irc_bot_name": "archlinuxmx-bot",
+    "irc_bot_realname": "Arch Linux MX bot, powered by TeleIRC <github.com/RITlug/teleirc>",
+    "irc_nickserv_user": "",
+    "irc_nickserv_pass": "",
+    "telegram_chat_id": "",
+    "teleirc_token": "",
+    "imgur_client_id": ""
 }


### PR DESCRIPTION
1. Why is this change neccesary?
Because we need to automate the process of configuring TeleIRC in order to
connect to the #archlinux-mx channel on Freenode.

2. How does it address the issue?
By adding the TeleIRC env config as a Jinja2 template that Ansible renders.

3. What side effects does this change have?
Closes #9.